### PR TITLE
Forslag til bedre navn på meldingstyper

### DIFF
--- a/KS.Fiks.IO.Politisk.Behandling.Client/KS.Fiks.IO.Politisk.Behandling.Client.csproj
+++ b/KS.Fiks.IO.Politisk.Behandling.Client/KS.Fiks.IO.Politisk.Behandling.Client.csproj
@@ -138,5 +138,17 @@
 			<Pack>true</Pack>
 			<PackageCopyToOutput>true</PackageCopyToOutput>
 		</Content>
+		<None Remove="Samples\delegertvedtak\sampleSendDelegertVedtak_InvalidExtraProperties.json" />
+		<Content Include="Samples\delegertvedtak\sampleSendDelegertVedtak_InvalidExtraProperties.json">
+		  	<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		  	<Pack>true</Pack>
+			<PackageCopyToOutput>true</PackageCopyToOutput>
+		</Content>
+		<None Remove="Samples\utvalgssak\sampleSendUtvalgssak_InvalidMissingRequiredProperty.json" />
+		<Content Include="Samples\utvalgssak\sampleSendUtvalgssak_InvalidMissingRequiredProperty.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+			<Pack>true</Pack>
+			<PackageCopyToOutput>true</PackageCopyToOutput>
+		</Content>
 	</ItemGroup>
 </Project>

--- a/KS.Fiks.IO.Politisk.Behandling.Client/KS.Fiks.IO.Politisk.Behandling.Client.csproj
+++ b/KS.Fiks.IO.Politisk.Behandling.Client/KS.Fiks.IO.Politisk.Behandling.Client.csproj
@@ -47,72 +47,76 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<None Remove="Schema\no.ks.fiks.politisk.behandling.hentmoeteplan.v1.schema.json" />
-		<None Remove="Schema\no.ks.fiks.politisk.behandling.resultatmoeteplan.v1.schema.json" />
-		<None Remove="Schema\no.ks.fiks.politisk.behandling.sendmoeteplaneinnsyn.v1.schema.json" />
-		<None Remove="Schema\no.ks.fiks.politisk.behandling.sendutvalgssakereinnsyn.v1.schema.json" />
-		<None Remove="Schema\no.ks.fiks.politisk.behandling.sendvedtakeinnsyn.v1.schema.json" />
-		<Content Include="Schema\no.ks.fiks.politisk.behandling.hentmoeteplan.v1.schema.json">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-			<Pack>true</Pack>
-			<PackageCopyToOutput>true</PackageCopyToOutput>
-		</Content>
-		<None Remove="Schema\no.ks.fiks.politisk.behandling.hentutvalg.v1.schema.json" />
-		<Content Include="Schema\no.ks.fiks.politisk.behandling.hentutvalg.v1.schema.json">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-			<Pack>true</Pack>
-			<PackageCopyToOutput>true</PackageCopyToOutput>
-		</Content>
-		<Content Include="Schema\no.ks.fiks.politisk.behandling.resultatmoeteplan.v1.schema.json">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-			<Pack>true</Pack>
-			<PackageCopyToOutput>true</PackageCopyToOutput>
-		</Content>
-		<None Remove="Schema\no.ks.fiks.politisk.behandling.resultatutvalg.v1.schema.json" />
-		<Content Include="Schema\no.ks.fiks.politisk.behandling.resultatutvalg.v1.schema.json">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-			<Pack>true</Pack>
-			<PackageCopyToOutput>true</PackageCopyToOutput>
-		</Content>
-		<None Remove="Schema\no.ks.fiks.politisk.behandling.senddelegertvedtak.v1.schema.json" />
-		<Content Include="Schema\no.ks.fiks.politisk.behandling.senddelegertvedtak.v1.schema.json">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-			<Pack>true</Pack>
-			<PackageCopyToOutput>true</PackageCopyToOutput>
-		</Content>
-		<None Remove="Schema\no.ks.fiks.politisk.behandling.sendorienteringssak.v1.schema.json" />
-		<Content Include="Schema\no.ks.fiks.politisk.behandling.sendmoeteplaneinnsyn.v1.schema.json">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-			<Pack>true</Pack>
-			<PackageCopyToOutput>true</PackageCopyToOutput>
-		</Content>
-		<Content Include="Schema\no.ks.fiks.politisk.behandling.sendorienteringssak.v1.schema.json">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-			<Pack>true</Pack>
-			<PackageCopyToOutput>true</PackageCopyToOutput>
-		</Content>
-		<None Remove="Schema\no.ks.fiks.politisk.behandling.sendutvalgssak.v1.schema.json" />
-		<Content Include="Schema\no.ks.fiks.politisk.behandling.sendutvalgssak.v1.schema.json">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-			<Pack>true</Pack>
-			<PackageCopyToOutput>true</PackageCopyToOutput>
-		</Content>
-		<None Remove="Schema\no.ks.fiks.politisk.behandling.sendvedtakfrautvalg.v1.schema.json" />
-		<Content Include="Schema\no.ks.fiks.politisk.behandling.sendutvalgssakereinnsyn.v1.schema.json">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-			<Pack>true</Pack>
-			<PackageCopyToOutput>true</PackageCopyToOutput>
-		</Content>
-		<Content Include="Schema\no.ks.fiks.politisk.behandling.sendvedtakeinnsyn.v1.schema.json">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-			<Pack>true</Pack>
-			<PackageCopyToOutput>true</PackageCopyToOutput>
-		</Content>
-		<Content Include="Schema\no.ks.fiks.politisk.behandling.sendvedtakfrautvalg.v1.schema.json">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-			<Pack>true</Pack>
-			<PackageCopyToOutput>true</PackageCopyToOutput>
-		</Content>
+
+	</ItemGroup>
+
+	<ItemGroup>
+	  <None Remove="Schema\no.ks.fiks.politisk.behandling.v1.delegertvedtak.send.schema.json" />
+	  <Content Include="Schema\no.ks.fiks.politisk.behandling.v1.delegertvedtak.send.schema.json">
+		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		  <Pack>true</Pack>
+		  <PackageCopyToOutput>true</PackageCopyToOutput>
+	  </Content>
+	  <None Remove="Schema\no.ks.fiks.politisk.behandling.v1.einnsyn.moeteplan.send.schema.json" />
+	  <Content Include="Schema\no.ks.fiks.politisk.behandling.v1.einnsyn.moeteplan.send.schema.json">
+		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		  <Pack>true</Pack>
+		  <PackageCopyToOutput>true</PackageCopyToOutput>
+	  </Content>
+	  <None Remove="Schema\no.ks.fiks.politisk.behandling.v1.einnsyn.utvalgssaker.send.schema.json" />
+	  <Content Include="Schema\no.ks.fiks.politisk.behandling.v1.einnsyn.utvalgssaker.send.schema.json">
+		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		  <Pack>true</Pack>
+		  <PackageCopyToOutput>true</PackageCopyToOutput>
+	  </Content>
+	  <None Remove="Schema\no.ks.fiks.politisk.behandling.v1.einnsyn.vedtak.send.schema.json" />
+	  <Content Include="Schema\no.ks.fiks.politisk.behandling.v1.einnsyn.vedtak.send.schema.json">
+		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		  <Pack>true</Pack>
+		  <PackageCopyToOutput>true</PackageCopyToOutput>
+	  </Content>
+	  <None Remove="Schema\no.ks.fiks.politisk.behandling.v1.moeteplan.hent.resultat.schema.json" />
+	  <Content Include="Schema\no.ks.fiks.politisk.behandling.v1.moeteplan.hent.resultat.schema.json">
+		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		  <Pack>true</Pack>
+		  <PackageCopyToOutput>true</PackageCopyToOutput>
+	  </Content>
+	  <None Remove="Schema\no.ks.fiks.politisk.behandling.v1.moeteplan.hent.schema.json" />
+	  <Content Include="Schema\no.ks.fiks.politisk.behandling.v1.moeteplan.hent.schema.json">
+		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		  <Pack>true</Pack>
+		  <PackageCopyToOutput>true</PackageCopyToOutput>
+	  </Content>
+	  <None Remove="Schema\no.ks.fiks.politisk.behandling.v1.orienteringssak.send.schema.json" />
+	  <Content Include="Schema\no.ks.fiks.politisk.behandling.v1.orienteringssak.send.schema.json">
+		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		  <Pack>true</Pack>
+		  <PackageCopyToOutput>true</PackageCopyToOutput>
+	  </Content>
+	  <None Remove="Schema\no.ks.fiks.politisk.behandling.v1.utvalg.hent.resultat.schema.json" />
+	  <Content Include="Schema\no.ks.fiks.politisk.behandling.v1.utvalg.hent.resultat.schema.json">
+		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		  <Pack>true</Pack>
+		  <PackageCopyToOutput>true</PackageCopyToOutput>
+	  </Content>
+	  <None Remove="Schema\no.ks.fiks.politisk.behandling.v1.utvalg.hent.schema.json" />
+	  <Content Include="Schema\no.ks.fiks.politisk.behandling.v1.utvalg.hent.schema.json">
+		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		  <Pack>true</Pack>
+		  <PackageCopyToOutput>true</PackageCopyToOutput>
+	  </Content>
+	  <None Remove="Schema\no.ks.fiks.politisk.behandling.v1.utvalgssak.send.schema.json" />
+	  <Content Include="Schema\no.ks.fiks.politisk.behandling.v1.utvalgssak.send.schema.json">
+		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		  <Pack>true</Pack>
+		  <PackageCopyToOutput>true</PackageCopyToOutput>
+	  </Content>
+	  <None Remove="Schema\no.ks.fiks.politisk.behandling.v1.vedtakfrautvalg.send.schema.json" />
+	  <Content Include="Schema\no.ks.fiks.politisk.behandling.v1.vedtakfrautvalg.send.schema.json">
+		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		  <Pack>true</Pack>
+		  <PackageCopyToOutput>true</PackageCopyToOutput>
+	  </Content>
 	</ItemGroup>
 
 </Project>

--- a/KS.Fiks.IO.Politisk.Behandling.Client/Models/PolitiskBehandlingMeldingTypeV1.cs
+++ b/KS.Fiks.IO.Politisk.Behandling.Client/Models/PolitiskBehandlingMeldingTypeV1.cs
@@ -3,28 +3,31 @@ namespace KS.Fiks.IO.Politiskbehandling.Client.Models
     public class PolitiskBehandlingMeldingTypeV1
     {
         // Forespørsler
-        public const string HentMoeteplan = "no.ks.fiks.politisk.behandling.hentmoeteplan.v1";
-        public const string HentUtvalg = "no.ks.fiks.politisk.behandling.hentutvalg.v1";
+        public const string HentMoeteplan = "no.ks.fiks.politisk.behandling.v1.moeteplan.hent";
+        public const string HentUtvalg = "no.ks.fiks.politisk.behandling.v1.utvalg.hent";
         
         // Resultat på forespørsler
-        public const string ResultatMoeteplan = "no.ks.fiks.politisk.behandling.resultatmoeteplan.v1";
-        public const string ResultatUtvalg = "no.ks.fiks.politisk.behandling.resultatutvalg.v1";
+        public const string ResultatMoeteplan = "no.ks.fiks.politisk.behandling.v1.moeteplan.hent.resultat";
+        public const string ResultatUtvalg = "no.ks.fiks.politisk.behandling.v1.utvalg.hent.resultat";
 
         // Utsendelser 
-        public const string SendVedtakFraUtvalg = "no.ks.fiks.politisk.behandling.sendvedtakfrautvalg.v1";
-        public const string SendVedtakFraUtvalgKvittering = "no.ks.fiks.politisk.behandling.sendvedtakfrautvalg.kvittering.v1";
+        public const string SendVedtakFraUtvalg = "no.ks.fiks.politisk.behandling.v1.vedtakfrautvalg.send";
+        public const string SendVedtakFraUtvalgKvittering = "no.ks.fiks.politisk.behandling.v1.vedtakfrautvalg.send.kvittering";
 
         // Innsendelser
-        public const string SendUtvalgssak = "no.ks.fiks.politisk.behandling.sendutvalgssak.v1";
-        public const string SendUtvalgssakKvittering = "no.ks.fiks.politisk.behandling.sendutvalgssak.kvittering.v1";
-        public const string SendOrienteringssak = "no.ks.fiks.politisk.behandling.sendorienteringssak.v1";
-        public const string SendOrienteringssakKvittering = "no.ks.fiks.politisk.behandling.sendorienteringssak.kvittering.v1";
-        public const string SendDelegertVedtak = "no.ks.fiks.politisk.behandling.senddelegertvedtak.v1";
-        public const string SendDelegertVedtakKvittering = "no.ks.fiks.politisk.behandling.senddelegertvedtak.kvittering.v1";
+        public const string SendUtvalgssak = "no.ks.fiks.politisk.behandling.v1.utvalgssak.send";
+        public const string SendUtvalgssakKvittering = "no.ks.fiks.politisk.behandling.v1.utvalgssak.send.kvittering";
+        public const string SendOrienteringssak = "no.ks.fiks.politisk.behandling.v1.orienteringssak.send";
+        public const string SendOrienteringssakKvittering = "no.ks.fiks.politisk.behandling.v1.orienteringssak.send.kvittering";
+        public const string SendDelegertVedtak = "no.ks.fiks.politisk.behandling.v1.delegertvedtak.send";
+        public const string SendDelegertVedtakKvittering = "no.ks.fiks.politisk.behandling.v1.delegertvedtak.send.kvittering";
 
         // eInnsyn
-        public const string SendMoeteplanTilEInnsyn = "no.ks.fiks.politisk.behandling.eInnsyn.sendmoeteplan.v1"; //TODO er dette eller schema navn korrekt?
-        public const string SendUtvalgssakerTilEInnsyn = "no.ks.fiks.politisk.behandling.eInnsyn.sendutvalgssaker.v1"; //TODO er dette eller schema navn korrekt?
-        public const string SendVedtakTilEInnsyn = "no.ks.fiks.politisk.behandling.eInnsyn.sendvedtak.v1"; //TODO er dette eller schema navn korrekt?
+        public const string SendMoeteplanTilEInnsyn = "no.ks.fiks.politisk.behandling.v1.eInnsyn.moeteplan.send";
+        public const string SendMoeteplanTilEInnsynKvittering = "no.ks.fiks.politisk.behandling.v1.eInnsyn.moeteplan.send.kvittering";
+        public const string SendUtvalgssakerTilEInnsyn = "no.ks.fiks.politisk.behandling.v1.eInnsyn.utvalgssaker.send";
+        public const string SendUtvalgssakerTilEInnsynKvittering = "no.ks.fiks.politisk.behandling.v1.eInnsyn.utvalgssaker.send.kvittering";
+        public const string SendVedtakTilEInnsyn = "no.ks.fiks.politisk.behandling.v1.eInnsyn.vedtak.send";
+        public const string SendVedtakTilEInnsynKvittering = "no.ks.fiks.politisk.behandling.v1.eInnsyn.vedtak.send.kvittering";
     }
 }

--- a/KS.Fiks.IO.Politisk.Behandling.Client/Schema/no.ks.fiks.politisk.behandling.v1.delegertvedtak.send.schema.json
+++ b/KS.Fiks.IO.Politisk.Behandling.Client/Schema/no.ks.fiks.politisk.behandling.v1.delegertvedtak.send.schema.json
@@ -1,64 +1,15 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://no.ks.fiks.politisk.behandling/SendVedtakFraUtvalg.v1.schema.json",
-    "title": "SendVedtakFraUtvalg",
-    "definitions": {
-        "Votering": {
-            "type": "object",
-            "properties": {
-                "moetedeltaker": {
-                    "type": "string"
-                },
-                "representerer": {
-                    "type": "string"
-                },
-                "stemme": {
-                    "type": "object",
-                    "properties": {
-                        "Ja": {
-                            "description": "None",
-                            "type": "object"
-                        },
-                        "Nei": {
-                            "description": "None",
-                            "type": "object"
-                        },
-                        "Blankt": {
-                            "description": "None",
-                            "type": "object"
-                        }
-                    },
-                    "required": [
-                        "Ja",
-                        "Nei",
-                        "Blankt"
-                    ]
-                }
-            },
-            "required": [
-                "moetedeltaker",
-                "representerer",
-                "stemme"
-            ]
-        }
-    },
+    "$id": "https://no.ks.fiks.politisk.behandling.v1/delegertVedtak.send.schema.json",
+    "title": "SendDelegertVedtak",
+    "definitions": {},
     "type": "object",
     "properties": {
-        "utvalgId": {
+        "tilUtvalgId": {
             "type": "string"
         },
-        "utvalgNavn": {
+        "tilUtvalgNavn": {
             "type": "string"
-        },
-        "moeteId": {
-            "type": "string"
-        },
-        "moetedato": {
-            "type": "string",
-            "format": "date-time"
-        },
-        "erEndeligVedtak": {
-            "type": "boolean"
         },
         "sak": {
             "type": "object",
@@ -170,12 +121,6 @@
                     "description": "Punkt",
                     "type": "object"
                 },
-                "votering": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Votering"
-                    }
-                },
                 "referanseForelderMappeEksternNoekkel": {
                     "type": "object",
                     "properties": {
@@ -233,19 +178,16 @@
             "required": [
                 "referanseEksternNoekkel",
                 "fagsystemetsSaksnummer",
-                "utvalgetsSaksnummer",
                 "tittel",
                 "vedtaksdato",
+                "status",
                 "saksansvarlig"
             ]
         }
     },
     "required": [
-        "utvalgId",
-        "utvalgNavn",
-        "moeteId",
-        "moetedato",
-        "erEndeligVedtak",
+        "tilUtvalgId",
+        "tilUtvalgNavn",
         "sak"
     ]
 }

--- a/KS.Fiks.IO.Politisk.Behandling.Client/Schema/no.ks.fiks.politisk.behandling.v1.einnsyn.moeteplan.send.schema.json
+++ b/KS.Fiks.IO.Politisk.Behandling.Client/Schema/no.ks.fiks.politisk.behandling.v1.einnsyn.moeteplan.send.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://no.ks.fiks.politisk.behandling/SendMoeteplanEinnsyn.v1.schema.json",
+    "$id": "https://no.ks.fiks.politisk.behandling.v1.einnsyn/moeteplan.send.schema.json",
     "title": "SendMoeteplanEinnsyn",
     "definitions": {
         "Utvalg": {

--- a/KS.Fiks.IO.Politisk.Behandling.Client/Schema/no.ks.fiks.politisk.behandling.v1.einnsyn.utvalgssaker.send.schema.json
+++ b/KS.Fiks.IO.Politisk.Behandling.Client/Schema/no.ks.fiks.politisk.behandling.v1.einnsyn.utvalgssaker.send.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://no.ks.fiks.politisk.behandling/SendUtvalgssakerEinnsyn.v1.schema.json",
+  "$id": "https://no.ks.fiks.politisk.behandling.v1.einnsyn/utvalgssaker.send.schema.json",
   "title": "SendUtvalgssakerEinnsyn",
   "definitions": {
     "Utvalgssakeinnsyn": {

--- a/KS.Fiks.IO.Politisk.Behandling.Client/Schema/no.ks.fiks.politisk.behandling.v1.einnsyn.vedtak.send.schema.json
+++ b/KS.Fiks.IO.Politisk.Behandling.Client/Schema/no.ks.fiks.politisk.behandling.v1.einnsyn.vedtak.send.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://no.ks.fiks.politisk.behandling/SendVedtakEinnsyn.v1.schema.json",
+  "$id": "https://no.ks.fiks.politisk.behandling.v1.einnsyn/vedtak.send.schema.json",
   "title": "SendVedtakEinnsyn",
   "definitions": {
     "VedtakFraUtvalgeinnsyn": {

--- a/KS.Fiks.IO.Politisk.Behandling.Client/Schema/no.ks.fiks.politisk.behandling.v1.moeteplan.hent.resultat.schema.json
+++ b/KS.Fiks.IO.Politisk.Behandling.Client/Schema/no.ks.fiks.politisk.behandling.v1.moeteplan.hent.resultat.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://no.ks.fiks.politisk.behandling/ResultatMoeteplan.v1.schema.json",
+  "$id": "https://no.ks.fiks.politisk.behandling.v1/moeteplan.hent.resultat.schema.json",
   "title": "ResultatMoeteplan",
   "definitions": {
     "Utvalg": {

--- a/KS.Fiks.IO.Politisk.Behandling.Client/Schema/no.ks.fiks.politisk.behandling.v1.moeteplan.hent.schema.json
+++ b/KS.Fiks.IO.Politisk.Behandling.Client/Schema/no.ks.fiks.politisk.behandling.v1.moeteplan.hent.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://no.ks.fiks.politisk.behandling/HentMoeteplan.v1.schema.json",
+    "$id": "https://no.ks.fiks.politisk.behandling.v1/moeteplan.hent.schema.json",
     "title": "HentMoeteplan",
     "definitions": {},
     "type": "object",

--- a/KS.Fiks.IO.Politisk.Behandling.Client/Schema/no.ks.fiks.politisk.behandling.v1.orienteringssak.send.schema.json
+++ b/KS.Fiks.IO.Politisk.Behandling.Client/Schema/no.ks.fiks.politisk.behandling.v1.orienteringssak.send.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://no.ks.fiks.politisk.behandling/SendOrienteringssak.v1.schema.json",
+    "$id": "https://no.ks.fiks.politisk.behandling.v1/orienteringssak.send.schema.json",
     "title": "SendOrienteringssak",
     "definitions": {
         "Behandlingsplan": {

--- a/KS.Fiks.IO.Politisk.Behandling.Client/Schema/no.ks.fiks.politisk.behandling.v1.utvalg.hent.resultat.schema.json
+++ b/KS.Fiks.IO.Politisk.Behandling.Client/Schema/no.ks.fiks.politisk.behandling.v1.utvalg.hent.resultat.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://no.ks.fiks.politisk.behandling/ResultatUtvalg.v1.schema.json",
+  "$id": "https://no.ks.fiks.politisk.behandling.v1/utvalg.hent.resultat.schema.json",
   "title": "ResultatUtvalg",
   "definitions": {
     "Utvalg": {

--- a/KS.Fiks.IO.Politisk.Behandling.Client/Schema/no.ks.fiks.politisk.behandling.v1.utvalg.hent.schema.json
+++ b/KS.Fiks.IO.Politisk.Behandling.Client/Schema/no.ks.fiks.politisk.behandling.v1.utvalg.hent.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://no.ks.fiks.politisk.behandling/HentUtvalg.v1.schema.json",
+  "$id": "https://no.ks.fiks.politisk.behandling.v1/utvalg.hent.schema.json",
   "title": "HentUtvalg",
   "definitions": {},
   "type": "object"

--- a/KS.Fiks.IO.Politisk.Behandling.Client/Schema/no.ks.fiks.politisk.behandling.v1.utvalgssak.send.schema.json
+++ b/KS.Fiks.IO.Politisk.Behandling.Client/Schema/no.ks.fiks.politisk.behandling.v1.utvalgssak.send.schema.json
@@ -1,16 +1,36 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://no.ks.fiks.politisk.behandling/SendDelegertVedtak.v1.schema.json",
-    "title": "SendDelegertVedtak",
-    "definitions": {},
+    "$id": "https://no.ks.fiks.politisk.behandling.v1/utvalgssak.send.schema.json",
+    "title": "SendUtvalgssak",
+    "definitions": {
+        "Behandlingsplan": {
+            "type": "object",
+            "properties": {
+                "tilUtvalgId": {
+                    "type": "string"
+                },
+                "tilUtvalgNavn": {
+                    "type": "string"
+                },
+                "tilMoeteId": {
+                    "type": "string"
+                },
+                "tilMoetedato": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "rekkefoelge": {
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "tilUtvalgId",
+                "tilUtvalgNavn"
+            ]
+        }
+    },
     "type": "object",
     "properties": {
-        "tilUtvalgId": {
-            "type": "string"
-        },
-        "tilUtvalgNavn": {
-            "type": "string"
-        },
         "sak": {
             "type": "object",
             "properties": {
@@ -44,40 +64,29 @@
                         "sakssekvensnummer"
                     ]
                 },
-                "utvalgetsSaksnummer": {
-                    "type": "object",
-                    "properties": {
-                        "saksaar": {
-                            "type": "integer"
-                        },
-                        "sakssekvensnummer": {
-                            "type": "integer"
-                        }
-                    },
-                    "required": [
-                        "saksaar",
-                        "sakssekvensnummer"
-                    ]
-                },
                 "tittel": {
                     "type": "string"
                 },
-                "vedtaksdato": {
-                    "type": "string",
-                    "format": "date"
-                },
-                "status": {
+                "saksbeskrivelse": {
                     "type": "object",
                     "properties": {
-                        "kodeverdi": {
+                        "tekstInnhold": {
                             "type": "string"
                         },
-                        "kodebeskrivelse": {
-                            "type": "string"
+                        "tekstFormat": {
+                            "type": "object",
+                            "properties": {
+                                "kodeverdi": {
+                                    "type": "string"
+                                },
+                                "kodebeskrivelse": {
+                                    "type": "string"
+                                }
+                            }
                         }
                     }
                 },
-                "vedtak": {
+                "forslagTilVedtak": {
                     "type": "object",
                     "properties": {
                         "tekstInnhold": {
@@ -179,15 +188,17 @@
                 "referanseEksternNoekkel",
                 "fagsystemetsSaksnummer",
                 "tittel",
-                "vedtaksdato",
-                "status",
                 "saksansvarlig"
             ]
+        },
+        "forslagTilBehandlingsplan": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/Behandlingsplan"
+            }
         }
     },
     "required": [
-        "tilUtvalgId",
-        "tilUtvalgNavn",
         "sak"
     ]
 }

--- a/KS.Fiks.IO.Politisk.Behandling.Client/Schema/no.ks.fiks.politisk.behandling.v1.vedtakfrautvalg.send.schema.json
+++ b/KS.Fiks.IO.Politisk.Behandling.Client/Schema/no.ks.fiks.politisk.behandling.v1.vedtakfrautvalg.send.schema.json
@@ -1,36 +1,65 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://no.ks.fiks.politisk.behandling/SendUtvalgssak.v1.schema.json",
-    "title": "SendUtvalgssak",
+    "$id": "https://no.ks.fiks.politisk.behandling.v1/vedtakFraUtvalg.send.schema.json",
+    "title": "SendVedtakFraUtvalg",
     "definitions": {
-        "Behandlingsplan": {
+        "Votering": {
             "type": "object",
             "properties": {
-                "tilUtvalgId": {
+                "moetedeltaker": {
                     "type": "string"
                 },
-                "tilUtvalgNavn": {
+                "representerer": {
                     "type": "string"
                 },
-                "tilMoeteId": {
-                    "type": "string"
-                },
-                "tilMoetedato": {
-                    "type": "string",
-                    "format": "date-time"
-                },
-                "rekkefoelge": {
-                    "type": "integer"
+                "stemme": {
+                    "type": "object",
+                    "properties": {
+                        "Ja": {
+                            "description": "None",
+                            "type": "object"
+                        },
+                        "Nei": {
+                            "description": "None",
+                            "type": "object"
+                        },
+                        "Blankt": {
+                            "description": "None",
+                            "type": "object"
+                        }
+                    },
+                    "required": [
+                        "Ja",
+                        "Nei",
+                        "Blankt"
+                    ]
                 }
             },
             "required": [
-                "tilUtvalgId",
-                "tilUtvalgNavn"
+                "moetedeltaker",
+                "representerer",
+                "stemme"
             ]
         }
     },
     "type": "object",
     "properties": {
+        "utvalgId": {
+            "type": "string"
+        },
+        "utvalgNavn": {
+            "type": "string"
+        },
+        "moeteId": {
+            "type": "string"
+        },
+        "moetedato": {
+            "type": "string",
+            "format": "date-time"
+        },
+        "erEndeligVedtak": {
+            "type": "boolean"
+        },
         "sak": {
             "type": "object",
             "properties": {
@@ -64,29 +93,40 @@
                         "sakssekvensnummer"
                     ]
                 },
+                "utvalgetsSaksnummer": {
+                    "type": "object",
+                    "properties": {
+                        "saksaar": {
+                            "type": "integer"
+                        },
+                        "sakssekvensnummer": {
+                            "type": "integer"
+                        }
+                    },
+                    "required": [
+                        "saksaar",
+                        "sakssekvensnummer"
+                    ]
+                },
                 "tittel": {
                     "type": "string"
                 },
-                "saksbeskrivelse": {
+                "vedtaksdato": {
+                    "type": "string",
+                    "format": "date"
+                },
+                "status": {
                     "type": "object",
                     "properties": {
-                        "tekstInnhold": {
+                        "kodeverdi": {
                             "type": "string"
                         },
-                        "tekstFormat": {
-                            "type": "object",
-                            "properties": {
-                                "kodeverdi": {
-                                    "type": "string"
-                                },
-                                "kodebeskrivelse": {
-                                    "type": "string"
-                                }
-                            }
+                        "kodebeskrivelse": {
+                            "type": "string"
                         }
                     }
                 },
-                "forslagTilVedtak": {
+                "vedtak": {
                     "type": "object",
                     "properties": {
                         "tekstInnhold": {
@@ -129,6 +169,12 @@
                 "posisjon": {
                     "description": "Punkt",
                     "type": "object"
+                },
+                "votering": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Votering"
+                    }
                 },
                 "referanseForelderMappeEksternNoekkel": {
                     "type": "object",
@@ -187,18 +233,19 @@
             "required": [
                 "referanseEksternNoekkel",
                 "fagsystemetsSaksnummer",
+                "utvalgetsSaksnummer",
                 "tittel",
+                "vedtaksdato",
                 "saksansvarlig"
             ]
-        },
-        "forslagTilBehandlingsplan": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/Behandlingsplan"
-            }
         }
     },
     "required": [
+        "utvalgId",
+        "utvalgNavn",
+        "moeteId",
+        "moetedato",
+        "erEndeligVedtak",
         "sak"
     ]
 }


### PR DESCRIPTION
Dette forslaget går ut på at vi skal lettere kunne identifisere hva en melding er og tilhører.
- V1 er flyttet til etter `politisk.behandling` for lettere identifisere versjon pr protokolltype. 
- Et objekt (vedtak, moteplan) står først, så handling og evt hvilket resultat det er. 
- Et resultat er knyttet tett opp mot handlingen den tilhører som f.eks.`hent.resultat`
- Einnsyn er lagt opp som et "sub domene" for politisk behandling, men som følger versjonering til politisk behandling
