### PR TITLE
Splittet ut referanseEksternNoekkel til en delt ressurs

### DIFF
--- a/KS.Fiks.IO.Politisk.Behandling.Client.Tests/MeldingTypeTests.cs
+++ b/KS.Fiks.IO.Politisk.Behandling.Client.Tests/MeldingTypeTests.cs
@@ -179,9 +179,18 @@ namespace KS.Fiks.IO.Politisk.Behandling.Client.Tests
         private static JSchema ValidationSchema(string meldingsType, string jsonPath, out JObject json)
         {
             var resolver = new JSchemaPreloadedResolver();
+            resolver.Add(new Uri("https://no.ks.fiks.protokoller/base/v1/referanseeksternnoekkel"), File.ReadAllText($"Schema/no.ks.fiks.protokoller.v1.base.referanseeksternnoekkel.schema.json"));
 
             var validationSchemaReader = File.OpenText($"Schema/{meldingsType}.schema.json");
-            var validationSchema = JSchema.Load(new JsonTextReader(validationSchemaReader), resolver);
+            var validationSchema = JSchema.Load(
+                new JsonTextReader(validationSchemaReader),
+                new JSchemaReaderSettings
+                {
+                    Resolver = resolver,
+                }
+            ); 
+                
+         
             
             AddAdditionalPropertiesFalseToSchemaProperties(validationSchema.Properties);
 

--- a/KS.Fiks.IO.Politisk.Behandling.Client/KS.Fiks.IO.Politisk.Behandling.Client.csproj
+++ b/KS.Fiks.IO.Politisk.Behandling.Client/KS.Fiks.IO.Politisk.Behandling.Client.csproj
@@ -48,6 +48,16 @@
 	</ItemGroup>
 	
 	<ItemGroup>
+	  <EmbeddedResource Include="Schema\no.ks.fiks.protokoller.v1.base.dokumentfil.schema.json">
+	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	    <Pack>true</Pack>
+	    <PackageCopyToOutput>true</PackageCopyToOutput>
+	  </EmbeddedResource>
+	  <EmbeddedResource Include="Schema\no.ks.fiks.protokoller.v1.base.referanseeksternnoekkel.schema.json">
+	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	    <Pack>true</Pack>
+	    <PackageCopyToOutput>true</PackageCopyToOutput>
+	  </EmbeddedResource>
 	  <None Remove="Schema\no.ks.fiks.politisk.behandling.v1.delegertvedtak.send.schema.json" />
 	  <EmbeddedResource Include="Schema\no.ks.fiks.politisk.behandling.v1.delegertvedtak.send.schema.json">
 		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/KS.Fiks.IO.Politisk.Behandling.Client/Schema/no.ks.fiks.politisk.behandling.v1.delegertvedtak.send.schema.json
+++ b/KS.Fiks.IO.Politisk.Behandling.Client/Schema/no.ks.fiks.politisk.behandling.v1.delegertvedtak.send.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://no.ks.fiks.politisk.behandling.v1/delegertVedtak.send.schema.json",
+    "$id": "https://no.ks.fiks.protokoller/politiskbehandling/v1/delegertvedtak/send",
     "title": "SendDelegertVedtak",
     "definitions": {},
     "type": "object",
@@ -14,21 +14,7 @@
         "sak": {
             "type": "object",
             "properties": {
-                "referanseEksternNoekkel": {
-                    "type": "object",
-                    "properties": {
-                        "fagsystem": {
-                            "type": "string"
-                        },
-                        "noekkel": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "fagsystem",
-                        "noekkel"
-                    ]
-                },
+                "referanseEksternNoekkel": { "$ref": "https://no.ks.fiks.protokoller/base/v1/referanseeksternnoekkel"},
                 "fagsystemetsSaksnummer": {
                     "type": "object",
                     "properties": {

--- a/KS.Fiks.IO.Politisk.Behandling.Client/Schema/no.ks.fiks.protokoller.v1.base.dokumentfil.schema.json
+++ b/KS.Fiks.IO.Politisk.Behandling.Client/Schema/no.ks.fiks.protokoller.v1.base.dokumentfil.schema.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://no.ks.fiks.protokoller/base/v1/dokumentfil",
+    "title": "Dokumenftil",
+    "type": "object",
+    "properties": {
+        "referanse": {
+            "type": "string"
+        },
+        "vedlegg": {
+            "type": "string"
+        }
+    },
+    "oneOf": [
+        {
+            "required": [
+                "referanse"
+            ]
+        },
+        {
+            "required": [
+                "vedlegg"
+            ]
+        }
+    ]
+}

--- a/KS.Fiks.IO.Politisk.Behandling.Client/Schema/no.ks.fiks.protokoller.v1.base.referanseeksternnoekkel.schema.json
+++ b/KS.Fiks.IO.Politisk.Behandling.Client/Schema/no.ks.fiks.protokoller.v1.base.referanseeksternnoekkel.schema.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://no.ks.fiks.protokoller/base/v1/referanseeksternnoekkel",
+    "title": "ReferanseEksternNoekkel",
+    "type": "object",
+    "properties": {
+        "fagsystem": {
+            "type": "string"
+        },
+        "noekkel": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "fagsystem",
+        "noekkel"
+    ]
+}


### PR DESCRIPTION
Har laget nytt schema for referanseEksternNoekkel. 
Denne kan da refereres til med $ref der man har denne datatypen. 
Dette bør gjøres kanskje med flere datatyper og de må flyttes ut til eget repo sånn at f.eks. Fiks-Plan og andre protokoller kan gjenbruke disse.